### PR TITLE
Fix for older iLO systems

### DIFF
--- a/plugins/module_utils/ilo_redfish_utils.py
+++ b/plugins/module_utils/ilo_redfish_utils.py
@@ -31,6 +31,8 @@ class iLORedfishUtils(RedfishUtils):
         data = response["data"]
 
         if "Oem" in data:
+            if 'Hp' in data["Oem"]:
+                data["Oem"]["Hpe"] = data["Oem"]["Hp"]
             if data["Oem"]["Hpe"]["Links"]["MySession"]["@odata.id"]:
                 current_session = data["Oem"]["Hpe"]["Links"]["MySession"]["@odata.id"]
 


### PR DESCRIPTION
On older iLO versions it seems to be that the dics have the key `Hp` instead of `Hpe`. I agree that my fix does not look very nice. Maybe someone with more python experience can improve this.