### PR TITLE
Fix typo in task name in roles/playbooks/User/listusers.yml

### DIFF
--- a/roles/playbooks/User/listusers.yml
+++ b/roles/playbooks/User/listusers.yml
@@ -36,7 +36,7 @@
         content: "{{ result_users | to_nice_json }}"
         dest: "{{ template }}.json"
 
-    - name: Delete session using security token created by CreateSesssion above
+    - name: Delete session using security token created by CreateSession above
       community.general.redfish_command:
         category: Sessions
         command: DeleteSession


### PR DESCRIPTION
## Overview

This PR resolves the following issue: https://github.com/HewlettPackard/ilo-ansible-collection/issues/33, it's a simple modification to a task name with no impact to the ability to run the playbook.