### PR TITLE
Fix CreateSession typo

### DIFF
--- a/roles/logout/tasks/main.yml
+++ b/roles/logout/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 # tasks file for Logout
-- name: Delete session using security token created by CreateSesssion above
+- name: Delete session using security token created by CreateSession above
   community.general.redfish_command:
     category: Sessions
     command: DeleteSession

--- a/roles/playbooks/Bios/disable_pxe.yml
+++ b/roles/playbooks/Bios/disable_pxe.yml
@@ -39,7 +39,7 @@
       auth_token: "{{ result.session.token }}"
     when: bios_attribute.changed
 
-  - name: Delete session using security token created by CreateSesssion above
+  - name: Delete session using security token created by CreateSession above
     community.general.redfish_command:
       category: Sessions
       command: DeleteSession

--- a/roles/playbooks/Bios/enable_pxe.yml
+++ b/roles/playbooks/Bios/enable_pxe.yml
@@ -39,7 +39,7 @@
         auth_token: "{{ result.session.token }}"
       when: bios_attribute.changed
 
-    - name: Delete session using security token created by CreateSesssion above
+    - name: Delete session using security token created by CreateSession above
       community.general.redfish_command:
         category: Sessions
         command: DeleteSession

--- a/roles/playbooks/Bios/get_bios_attributes.yml
+++ b/roles/playbooks/Bios/get_bios_attributes.yml
@@ -36,7 +36,7 @@
         content: "{{ result_attr | to_nice_json }}"
         dest: "{{ template }}.json"
 
-    - name: Delete session using security token created by CreateSesssion above
+    - name: Delete session using security token created by CreateSession above
       community.general.redfish_command:
         category: Sessions
         command: DeleteSession

--- a/roles/playbooks/Bios/get_bios_boot_order.yml
+++ b/roles/playbooks/Bios/get_bios_boot_order.yml
@@ -37,7 +37,7 @@
       content: "{{ result_boot | to_nice_json }}"
       dest: "{{ template }}.json"
 
-  - name: Delete session using security token created by CreateSesssion above
+  - name: Delete session using security token created by CreateSession above
     community.general.redfish_command:
       category: Sessions
       command: DeleteSession

--- a/roles/playbooks/Bios/get_boot_override.yml
+++ b/roles/playbooks/Bios/get_boot_override.yml
@@ -37,7 +37,7 @@
       content: "{{ result_ovr | to_nice_json }}"
       dest: "{{ template }}.json"
 
-  - name: Delete session using security token created by CreateSesssion above
+  - name: Delete session using security token created by CreateSession above
     community.general.redfish_command:
       category: Sessions
       command: DeleteSession

--- a/roles/playbooks/Bios/reboot_system.yml
+++ b/roles/playbooks/Bios/reboot_system.yml
@@ -23,7 +23,7 @@
         # password: "{{ password }}"
         auth_token: "{{ result.session.token }}"
 
-    - name: Delete session using security token created by CreateSesssion above
+    - name: Delete session using security token created by CreateSession above
       community.general.redfish_command:
         category: Sessions
         command: DeleteSession

--- a/roles/playbooks/Bios/set_bios_attribute.yml
+++ b/roles/playbooks/Bios/set_bios_attribute.yml
@@ -51,7 +51,7 @@
         auth_token: "{{ result.session.token }}"
       when: bios_attribute.changed
 
-    - name: Delete session using security token created by CreateSesssion above
+    - name: Delete session using security token created by CreateSession above
       community.general.redfish_command:
         category: Sessions
         command: DeleteSession

--- a/roles/playbooks/Bios/set_bootmode_legacybios.yml
+++ b/roles/playbooks/Bios/set_bootmode_legacybios.yml
@@ -39,7 +39,7 @@
         auth_token: "{{ result.session.token }}"
       when: bios_attribute.changed
 
-    - name: Delete session using security token created by CreateSesssion above
+    - name: Delete session using security token created by CreateSession above
       community.general.redfish_command:
         category: Sessions
         command: DeleteSession

--- a/roles/playbooks/Bios/set_bootmode_uefi.yml
+++ b/roles/playbooks/Bios/set_bootmode_uefi.yml
@@ -40,7 +40,7 @@
         auth_token: "{{ result.session.token }}"
       when: bios_attribute.changed
 
-    - name: Delete session using security token created by CreateSesssion above
+    - name: Delete session using security token created by CreateSession above
       community.general.redfish_command:
         category: Sessions
         command: DeleteSession

--- a/roles/playbooks/Bios/set_default_bios_settings.yml
+++ b/roles/playbooks/Bios/set_default_bios_settings.yml
@@ -35,7 +35,7 @@
         auth_token: "{{ result.session.token }}"
       when: bios_default.changed
 
-    - name: Delete session using security token created by CreateSesssion above
+    - name: Delete session using security token created by CreateSession above
       community.general.redfish_command:
         category: Sessions
         command: DeleteSession

--- a/roles/playbooks/Bios/set_onetime_boot.yml
+++ b/roles/playbooks/Bios/set_onetime_boot.yml
@@ -34,7 +34,7 @@
         auth_token: "{{ result.session.token }}"
       register: bios_onetimeboot
 
-    - name: Delete session using security token created by CreateSesssion above
+    - name: Delete session using security token created by CreateSession above
       community.general.redfish_command:
         category: Sessions
         command: DeleteSession

--- a/roles/playbooks/Chassis/get_chassis_inventory.yml
+++ b/roles/playbooks/Chassis/get_chassis_inventory.yml
@@ -36,7 +36,7 @@
         content: "{{ result_inv | to_nice_json }}"
         dest: "{{ template }}.json"
 
-    - name: Delete session using security token created by CreateSesssion above
+    - name: Delete session using security token created by CreateSession above
       community.general.redfish_command:
         category: Sessions
         command: DeleteSession

--- a/roles/playbooks/Chassis/get_chassis_power.yml
+++ b/roles/playbooks/Chassis/get_chassis_power.yml
@@ -36,7 +36,7 @@
         content: "{{ result_pow | to_nice_json }}"
         dest: "{{ template }}.json"
 
-    - name: Delete session using security token created by CreateSesssion above
+    - name: Delete session using security token created by CreateSession above
       community.general.redfish_command:
         category: Sessions
         command: DeleteSession

--- a/roles/playbooks/Chassis/get_chassis_thermals.yml
+++ b/roles/playbooks/Chassis/get_chassis_thermals.yml
@@ -36,7 +36,7 @@
         content: "{{ result_thermal | to_nice_json }}"
         dest: "{{ template }}.json"
 
-    - name: Delete session using security token created by CreateSesssion above
+    - name: Delete session using security token created by CreateSession above
       community.general.redfish_command:
         category: Sessions
         command: DeleteSession

--- a/roles/playbooks/Chassis/indicator_led_off.yml
+++ b/roles/playbooks/Chassis/indicator_led_off.yml
@@ -24,7 +24,7 @@
         # password: "{{ password }}"
         auth_token: "{{ result.session.token }}"
 
-    - name: Delete session using security token created by CreateSesssion above
+    - name: Delete session using security token created by CreateSession above
       community.general.redfish_command:
         category: Sessions
         command: DeleteSession

--- a/roles/playbooks/Chassis/indicator_led_on.yml
+++ b/roles/playbooks/Chassis/indicator_led_on.yml
@@ -24,7 +24,7 @@
         # password: "{{ password }}"
         auth_token: "{{ result.session.token }}"
 
-    - name: Delete session using security token created by CreateSesssion above
+    - name: Delete session using security token created by CreateSession above
       community.general.redfish_command:
         category: Sessions
         command: DeleteSession

--- a/roles/playbooks/Inventory/get_cpu_inventory.yml
+++ b/roles/playbooks/Inventory/get_cpu_inventory.yml
@@ -36,7 +36,7 @@
         content: "{{ result_inv | to_nice_json }}"
         dest: "{{ template }}.json"
 
-    - name: Delete session using security token created by CreateSesssion above
+    - name: Delete session using security token created by CreateSession above
       community.general.redfish_command:
         category: Sessions
         command: DeleteSession

--- a/roles/playbooks/Inventory/get_disk_inventory.yml
+++ b/roles/playbooks/Inventory/get_disk_inventory.yml
@@ -37,7 +37,7 @@
         content: "{{ result_storage | to_nice_json }}"
         dest: "{{ template }}.json"
 
-    - name: Delete session using security token created by CreateSesssion above
+    - name: Delete session using security token created by CreateSession above
       community.general.redfish_command:
         category: Sessions
         command: DeleteSession

--- a/roles/playbooks/Inventory/get_fan_inventory.yml
+++ b/roles/playbooks/Inventory/get_fan_inventory.yml
@@ -36,7 +36,7 @@
         content: "{{ result_fan | to_nice_json }}"
         dest: "{{ template }}.json"
 
-    - name: Delete session using security token created by CreateSesssion above
+    - name: Delete session using security token created by CreateSession above
       community.general.redfish_command:
         category: Sessions
         command: DeleteSession

--- a/roles/playbooks/Inventory/get_firmware_inventory.yml
+++ b/roles/playbooks/Inventory/get_firmware_inventory.yml
@@ -36,7 +36,7 @@
         content: "{{ result_fw | to_nice_json }}"
         dest: "{{ template }}.json"
 
-    - name: Delete session using security token created by CreateSesssion above
+    - name: Delete session using security token created by CreateSession above
       community.general.redfish_command:
         category: Sessions
         command: DeleteSession

--- a/roles/playbooks/Inventory/get_firmware_update_methods.yml
+++ b/roles/playbooks/Inventory/get_firmware_update_methods.yml
@@ -36,7 +36,7 @@
         content: "{{ result_fw | to_nice_json }}"
         dest: "{{ template }}.json"
 
-    - name: Delete session using security token created by CreateSesssion above
+    - name: Delete session using security token created by CreateSession above
       community.general.redfish_command:
         category: Sessions
         command: DeleteSession

--- a/roles/playbooks/Inventory/get_memory_inventory.yml
+++ b/roles/playbooks/Inventory/get_memory_inventory.yml
@@ -36,7 +36,7 @@
         content: "{{ result_mem | to_nice_json }}"
         dest: "{{ template }}.json"
 
-    - name: Delete session using security token created by CreateSesssion above
+    - name: Delete session using security token created by CreateSession above
       community.general.redfish_command:
         category: Sessions
         command: DeleteSession

--- a/roles/playbooks/Inventory/get_nic_inventory.yml
+++ b/roles/playbooks/Inventory/get_nic_inventory.yml
@@ -36,7 +36,7 @@
         content: "{{ result_nic | to_nice_json }}"
         dest: "{{ template }}.json"
 
-    - name: Delete session using security token created by CreateSesssion above
+    - name: Delete session using security token created by CreateSession above
       community.general.redfish_command:
         category: Sessions
         command: DeleteSession

--- a/roles/playbooks/Inventory/get_psu_inventory.yml
+++ b/roles/playbooks/Inventory/get_psu_inventory.yml
@@ -36,7 +36,7 @@
         content: "{{ result_psu | to_nice_json }}"
         dest: "{{ template }}.json"
 
-    - name: Delete session using security token created by CreateSesssion above
+    - name: Delete session using security token created by CreateSession above
       community.general.redfish_command:
         category: Sessions
         command: DeleteSession

--- a/roles/playbooks/Inventory/get_sessions_inventory.yml
+++ b/roles/playbooks/Inventory/get_sessions_inventory.yml
@@ -36,7 +36,7 @@
         content: "{{ result_sessions | to_nice_json }}"
         dest: "{{ template }}.json"
 
-    - name: Delete session using security token created by CreateSesssion above
+    - name: Delete session using security token created by CreateSession above
       community.general.redfish_command:
         category: Sessions
         command: DeleteSession

--- a/roles/playbooks/Inventory/get_software_inventory.yml
+++ b/roles/playbooks/Inventory/get_software_inventory.yml
@@ -36,7 +36,7 @@
         content: "{{ result_fw | to_nice_json }}"
         dest: "{{ template }}.json"
 
-    - name: Delete session using security token created by CreateSesssion above
+    - name: Delete session using security token created by CreateSession above
       community.general.redfish_command:
         category: Sessions
         command: DeleteSession

--- a/roles/playbooks/Inventory/get_storage_cont_inventory.yml
+++ b/roles/playbooks/Inventory/get_storage_cont_inventory.yml
@@ -36,7 +36,7 @@
         content: "{{ result_storage | to_nice_json }}"
         dest: "{{ template }}.json"
 
-    - name: Delete session using security token created by CreateSesssion above
+    - name: Delete session using security token created by CreateSession above
       community.general.redfish_command:
         category: Sessions
         command: DeleteSession

--- a/roles/playbooks/Inventory/get_system_inventory.yml
+++ b/roles/playbooks/Inventory/get_system_inventory.yml
@@ -36,7 +36,7 @@
         content: "{{ result_inv | to_nice_json }}"
         dest: "{{ template }}.json"
 
-    - name: Delete session using security token created by CreateSesssion above
+    - name: Delete session using security token created by CreateSession above
       community.general.redfish_command:
         category: Sessions
         command: DeleteSession

--- a/roles/playbooks/Inventory/get_system_inventory_all.yml
+++ b/roles/playbooks/Inventory/get_system_inventory_all.yml
@@ -36,7 +36,7 @@
         content: "{{ result_inv | to_nice_json }}"
         dest: "{{ template }}.json"
 
-    - name: Delete session using security token created by CreateSesssion above
+    - name: Delete session using security token created by CreateSession above
       community.general.redfish_command:
         category: Sessions
         command: DeleteSession

--- a/roles/playbooks/Inventory/get_system_inventory_default.yml
+++ b/roles/playbooks/Inventory/get_system_inventory_default.yml
@@ -35,7 +35,7 @@
         content: "{{ result_inv | to_nice_json }}"
         dest: "{{ template }}.json"
 
-    - name: Delete session using security token created by CreateSesssion above
+    - name: Delete session using security token created by CreateSession above
       community.general.redfish_command:
         category: Sessions
         command: DeleteSession

--- a/roles/playbooks/Inventory/get_volume_inventory.yml
+++ b/roles/playbooks/Inventory/get_volume_inventory.yml
@@ -36,7 +36,7 @@
         content: "{{ result_vol | to_nice_json }}"
         dest: "{{ template }}.json"
 
-    - name: Delete session using security token created by CreateSesssion above
+    - name: Delete session using security token created by CreateSession above
       community.general.redfish_command:
         category: Sessions
         command: DeleteSession

--- a/roles/playbooks/Manager/clear_logs.yml
+++ b/roles/playbooks/Manager/clear_logs.yml
@@ -24,7 +24,7 @@
       # password: "{{ password }}"
       auth_token: "{{ result.session.token }}"
 
-  - name: Delete session using security token created by CreateSesssion above
+  - name: Delete session using security token created by CreateSession above
     community.general.redfish_command:
       category: Sessions
       command: DeleteSession

--- a/roles/playbooks/Manager/config_hostname.yml
+++ b/roles/playbooks/Manager/config_hostname.yml
@@ -30,7 +30,7 @@
         # password: "{{ password }}"
         auth_token: "{{ result.session.token }}"
 
-    - name: Delete session using security token created by CreateSesssion above
+    - name: Delete session using security token created by CreateSession above
       community.general.redfish_command:
         category: Sessions
         command: DeleteSession

--- a/roles/playbooks/Manager/disable_winsreg.yml
+++ b/roles/playbooks/Manager/disable_winsreg.yml
@@ -28,7 +28,7 @@
         attribute_name: "{{ attribute_name }}"
         auth_token: "{{ result.session.token }}"
 
-    - name: Delete session using security token created by CreateSesssion above
+    - name: Delete session using security token created by CreateSession above
       community.general.redfish_command:
         category: Sessions
         command: DeleteSession

--- a/roles/playbooks/Manager/get_health_report.yml
+++ b/roles/playbooks/Manager/get_health_report.yml
@@ -37,7 +37,7 @@
       content: "{{ result_vm | to_nice_json }}"
       dest: "{{ template }}.json"
 
-  - name: Delete session using security token created by CreateSesssion above
+  - name: Delete session using security token created by CreateSession above
     community.general.redfish_command:
       category: Sessions
       command: DeleteSession

--- a/roles/playbooks/Manager/get_host_interfaces.yml
+++ b/roles/playbooks/Manager/get_host_interfaces.yml
@@ -37,7 +37,7 @@
       content: "{{ result_vm | to_nice_json }}"
       dest: "{{ template }}.json"
 
-  - name: Delete session using security token created by CreateSesssion above
+  - name: Delete session using security token created by CreateSession above
     community.general.redfish_command:
       category: Sessions
       command: DeleteSession

--- a/roles/playbooks/Manager/get_manager_inventory.yml
+++ b/roles/playbooks/Manager/get_manager_inventory.yml
@@ -36,7 +36,7 @@
         content: "{{ result_fw | to_nice_json }}"
         dest: "{{ template }}.json"
 
-    - name: Delete session using security token created by CreateSesssion above
+    - name: Delete session using security token created by CreateSession above
       community.general.redfish_command:
         category: Sessions
         command: DeleteSession

--- a/roles/playbooks/Manager/get_manager_logs.yml
+++ b/roles/playbooks/Manager/get_manager_logs.yml
@@ -37,7 +37,7 @@
       content: "{{ result_logs | to_nice_json }}"
       dest: "{{ template }}.json"
 
-  - name: Delete session using security token created by CreateSesssion above
+  - name: Delete session using security token created by CreateSession above
     community.general.redfish_command:
       category: Sessions
       command: DeleteSession

--- a/roles/playbooks/Manager/get_manager_nic_inventory.yml
+++ b/roles/playbooks/Manager/get_manager_nic_inventory.yml
@@ -37,7 +37,7 @@
       content: "{{ result_nic | to_nice_json }}"
       dest: "{{ template }}.json"
 
-  - name: Delete session using security token created by CreateSesssion above
+  - name: Delete session using security token created by CreateSession above
     community.general.redfish_command:
       category: Sessions
       command: DeleteSession

--- a/roles/playbooks/Manager/get_network_protocols.yml
+++ b/roles/playbooks/Manager/get_network_protocols.yml
@@ -37,7 +37,7 @@
       content: "{{ result_vm | to_nice_json }}"
       dest: "{{ template }}.json"
 
-  - name: Delete session using security token created by CreateSesssion above
+  - name: Delete session using security token created by CreateSession above
     community.general.redfish_command:
       category: Sessions
       command: DeleteSession

--- a/roles/playbooks/Manager/get_virtual_media.yml
+++ b/roles/playbooks/Manager/get_virtual_media.yml
@@ -37,7 +37,7 @@
       content: "{{ result_vm | to_nice_json }}"
       dest: "{{ template }}.json"
 
-  - name: Delete session using security token created by CreateSesssion above
+  - name: Delete session using security token created by CreateSession above
     community.general.redfish_command:
       category: Sessions
       command: DeleteSession

--- a/roles/playbooks/Manager/ilo_nicsettings.yml
+++ b/roles/playbooks/Manager/ilo_nicsettings.yml
@@ -79,7 +79,7 @@
         # password: "{{ password }}"
         auth_token: "{{ result.session.token }}"
 
-    - name: Delete session using security token created by CreateSesssion above
+    - name: Delete session using security token created by CreateSession above
       community.general.redfish_command:
         category: Sessions
         command: DeleteSession

--- a/roles/playbooks/Manager/restart_manager.yml
+++ b/roles/playbooks/Manager/restart_manager.yml
@@ -24,7 +24,7 @@
       # password: "{{ password }}"
       auth_token: "{{ result.session.token }}"
 
-  - name: Delete session using security token created by CreateSesssion above
+  - name: Delete session using security token created by CreateSession above
     community.general.redfish_command:
       category: Sessions
       command: DeleteSession

--- a/roles/playbooks/Manager/set_dns.yml
+++ b/roles/playbooks/Manager/set_dns.yml
@@ -41,7 +41,7 @@
         attribute_value: "{{ domain_name }}"
         auth_token: "{{ result.session.token }}"
 
-    - name: Delete session using security token created by CreateSesssion above
+    - name: Delete session using security token created by CreateSession above
       community.general.redfish_command:
         category: Sessions
         command: DeleteSession

--- a/roles/playbooks/Manager/set_ntpservers.yml
+++ b/roles/playbooks/Manager/set_ntpservers.yml
@@ -30,7 +30,7 @@
         attribute_value: "{{ attribute_value }}"
         auth_token: "{{ result.session.token }}"
 
-    - name: Delete session using security token created by CreateSesssion above
+    - name: Delete session using security token created by CreateSession above
       community.general.redfish_command:
         category: Sessions
         command: DeleteSession

--- a/roles/playbooks/Manager/set_timezone.yml
+++ b/roles/playbooks/Manager/set_timezone.yml
@@ -29,7 +29,7 @@
       attribute_value: "{{ attribute_value }}"
       auth_token: "{{ result.session.token }}"
 
-  - name: Delete session using security token created by CreateSesssion above
+  - name: Delete session using security token created by CreateSession above
     community.general.redfish_command:
       category: Sessions
       command: DeleteSession

--- a/roles/playbooks/Power/power_force_off.yml
+++ b/roles/playbooks/Power/power_force_off.yml
@@ -24,7 +24,7 @@
         # password: "{{ password }}"
         auth_token: "{{ result.session.token }}"
 
-    - name: Delete session using security token created by CreateSesssion above
+    - name: Delete session using security token created by CreateSession above
       community.general.redfish_command:
         category: Sessions
         command: DeleteSession

--- a/roles/playbooks/Power/power_graceful_restart.yml
+++ b/roles/playbooks/Power/power_graceful_restart.yml
@@ -24,7 +24,7 @@
         # password: "{{ password }}"
         auth_token: "{{ result.session.token }}"
 
-    - name: Delete session using security token created by CreateSesssion above
+    - name: Delete session using security token created by CreateSession above
       community.general.redfish_command:
         category: Sessions
         command: DeleteSession

--- a/roles/playbooks/Power/power_graceful_shutdown.yml
+++ b/roles/playbooks/Power/power_graceful_shutdown.yml
@@ -24,7 +24,7 @@
         # password: "{{ password }}"
         auth_token: "{{ result.session.token }}"
 
-    - name: Delete session using security token created by CreateSesssion above
+    - name: Delete session using security token created by CreateSession above
       community.general.redfish_command:
         category: Sessions
         command: DeleteSession

--- a/roles/playbooks/Power/power_on.yml
+++ b/roles/playbooks/Power/power_on.yml
@@ -24,7 +24,7 @@
         # password: "{{ password }}"
         auth_token: "{{ result.session.token }}"
 
-    - name: Delete session using security token created by CreateSesssion above
+    - name: Delete session using security token created by CreateSession above
       community.general.redfish_command:
         category: Sessions
         command: DeleteSession

--- a/roles/playbooks/User/adduser.yml
+++ b/roles/playbooks/User/adduser.yml
@@ -32,7 +32,7 @@
         roleid: "{{ role_id }}"
         auth_token: "{{ result.session.token }}"
         
-    - name: Delete session using security token created by CreateSesssion above
+    - name: Delete session using security token created by CreateSession above
       community.general.redfish_command:
         category: Sessions
         command: DeleteSession

--- a/roles/playbooks/User/deluser.yml
+++ b/roles/playbooks/User/deluser.yml
@@ -29,7 +29,7 @@
         auth_token: "{{ result.session.token }}"
 
 
-    - name: Delete session using security token created by CreateSesssion above
+    - name: Delete session using security token created by CreateSession above
       community.general.redfish_command:
         category: Sessions
         command: DeleteSession

--- a/roles/playbooks/User/updatepass.yml
+++ b/roles/playbooks/User/updatepass.yml
@@ -30,7 +30,7 @@
         account_password: "{{ new_pass }}"
         auth_token: "{{ result.session.token }}"
         
-    - name: Delete session using security token created by CreateSesssion above
+    - name: Delete session using security token created by CreateSession above
       community.general.redfish_command:
         category: Sessions
         command: DeleteSession

--- a/roles/playbooks/User/updateusername.yml
+++ b/roles/playbooks/User/updateusername.yml
@@ -30,7 +30,7 @@
         account_updatename: "{{ account_updatename }}"
         auth_token: "{{ result.session.token }}"
 
-    - name: Delete session using security token created by CreateSesssion above
+    - name: Delete session using security token created by CreateSession above
       community.general.redfish_command:
         category: Sessions
         command: DeleteSession

--- a/roles/playbooks/User/updateuserrole.yml
+++ b/roles/playbooks/User/updateuserrole.yml
@@ -30,7 +30,7 @@
         roleid: "{{ roleid }}"
         auth_token: "{{ result.session.token }}"
 
-    - name: Delete session using security token created by CreateSesssion above
+    - name: Delete session using security token created by CreateSession above
       community.general.redfish_command:
         category: Sessions
         command: DeleteSession

--- a/tests/integration/targets/Manager_test/tasks/main.yml
+++ b/tests/integration/targets/Manager_test/tasks/main.yml
@@ -61,7 +61,7 @@
     attribute_value: Chennai
     auth_token: "{{ result.session.token }}"
 
-- name: Delete session using security token created by CreateSesssion above
+- name: Delete session using security token created by CreateSession above
   redfish_command:
     category: Sessions
     command: DeleteSession


### PR DESCRIPTION
I've replaced all instances of `CreateSesssion` with `CreateSession` to resolve all typos. All of these modifications are non-breaking changes, as all misspellings were found in the names of Ansible playbook tasks, not the actual command itself.