### PR TITLE
Update ilo_oem_utils.py

### DIFF
--- a/plugins/module_utils/ilo_oem_utils.py
+++ b/plugins/module_utils/ilo_oem_utils.py
@@ -950,10 +950,10 @@ class iLOOemUtils(RedfishUtils):
             result["logical_drives"] = logical_drives
             result["logical_drives_count"] = logical_drives_count
 
-            return {
-                "msg": result,
-                "ret": True
-            }
+        return {
+            "msg": result,
+            "ret": True
+        }
 
     def remove_odata(self, output):
         # Remove odata variables given in the list


### PR DESCRIPTION
Fixed indentation on return to allow multiple array controllers to report their logical drives.

Addresses Issue #41 