### PR TITLE
fix: Remove incorrect task-level play configuration from role

### DIFF
--- a/roles/delete_volumes/tasks/main.yml
+++ b/roles/delete_volumes/tasks/main.yml
@@ -1,51 +1,47 @@
 ---
-- hosts: myhosts
-  connection: local
-  gather_facts: False
-  tasks:
-    - name: Validate server authentication input provided by user
-      fail:
-        msg: "username/password or auth_token is mandatory"
-      when:
-        - (username is not defined or password is not defined) and (auth_token is not defined)
+- name: Validate server authentication input provided by user
+  fail:
+    msg: "username/password or auth_token is mandatory"
+  when:
+    - (username is not defined or password is not defined) and (auth_token is not defined)
 
-    - name: Fail when more than one valid authentication method is provided
-      fail:
-        msg: "Only one authentication method is allowed. Provide either username/password or auth_token."
-      when:
-        - ((username is defined or password is defined) and auth_token is defined)
+- name: Fail when more than one valid authentication method is provided
+  fail:
+    msg: "Only one authentication method is allowed. Provide either username/password or auth_token."
+  when:
+    - ((username is defined or password is defined) and auth_token is defined)
 
-    - name: Delete all volumes when username and password are defined
-      block:
-        - community.general.redfish_config:
-            category: Systems
-            command: DeleteVolumes
-            baseuri: "{{ baseuri }}"
-            username: "{{ username }}"
-            password: "{{ password }}"
-            storage_subsystem_id: "{{ storage_subsystem_id }}"
-            volume_ids: "{{ volume_ids }}"
-          register: result
+- name: Delete all volumes when username and password are defined
+  block:
+    - community.general.redfish_config:
+        category: Systems
+        command: DeleteVolumes
+        baseuri: "{{ baseuri }}"
+        username: "{{ username }}"
+        password: "{{ password }}"
+        storage_subsystem_id: "{{ storage_subsystem_id }}"
+        volume_ids: "{{ volume_ids }}"
+      register: result
 
-        - name: Status
-          debug:
-            msg: "{{ result }}"
+    - name: Status
+      debug:
+        msg: "{{ result }}"
 
-      when: username is defined and password is defined
+  when: username is defined and password is defined
 
-    - name: Delete all volumes when auth_token are defined
-      block:
-        - community.general.redfish_config:
-            category: Systems
-            command: DeleteVolumes
-            baseuri: "{{ baseuri }}"
-            auth_token: "{{ auth_token }}"
-            storage_subsystem_id: "{{ storage_subsystem_id }}"
-            volume_ids: "{{ volume_ids }}"
-          register: result
+- name: Delete all volumes when auth_token are defined
+  block:
+    - community.general.redfish_config:
+        category: Systems
+        command: DeleteVolumes
+        baseuri: "{{ baseuri }}"
+        auth_token: "{{ auth_token }}"
+        storage_subsystem_id: "{{ storage_subsystem_id }}"
+        volume_ids: "{{ volume_ids }}"
+      register: result
 
-        - name: Status
-          debug:
-            msg: "{{ result }}"
+    - name: Status
+      debug:
+        msg: "{{ result }}"
 
-      when: auth_token is defined
+  when: auth_token is defined


### PR DESCRIPTION
The role previously included hosts, connection, and gather_facts configurations within its task definition, which caused failures when the role was called directly. These configurations are unnecessary within a role and should be defined at the playbook level instead.

This commit removes the incorrect configurations, ensuring that the role starts directly with tasks in main.yml, making it reusable and compatible with different playbooks.

Fixes Issue : https://github.com/HewlettPackard/ilo-ansible-collection/issues/50