### PR TITLE
Remove force requirement for fwpkg_file

### DIFF
--- a/plugins/modules/ilo_redfish_command.py
+++ b/plugins/modules/ilo_redfish_command.py
@@ -59,7 +59,6 @@ options:
     default: 10
     type: int
   fwpkg_file:
-    required: true
     description:
       - Absolute path of the firmware package file that the user wishes to attach.
   force:


### PR DESCRIPTION
This parameter should not be force required as it removes the ability to perform arbitrary redfish commands that are not related to firmware package upgrades.